### PR TITLE
Change Host Translation

### DIFF
--- a/custom_components/reolink_dev/translations/de.json
+++ b/custom_components/reolink_dev/translations/de.json
@@ -11,7 +11,7 @@
         "step": {
             "user": {
                 "data": {
-                    "host": "Host",
+                    "host": "Kamera",
                     "port": "Port",
                     "username": "Benutzername",
                     "password": "Passwort"
@@ -26,7 +26,7 @@
                     "stream": "Stream",
                     "protocol": "Protokoll",
                     "channel": "Kanal",
-					"motion_off_delay": "Bewegungssensor Ausschaltverzögerung (Sekunden)"
+		    "motion_off_delay": "Bewegungssensor Ausschaltverzögerung (Sekunden)"
                 }
             }
         }


### PR DESCRIPTION
After testing the config flow it makes more sense to translate "Host" to "Kamera". Might be also good for EN and NL