### PR TITLE
translation: add Swedish translation

### DIFF
--- a/custom_components/reolink_dev/translations/se.json
+++ b/custom_components/reolink_dev/translations/se.json
@@ -1,0 +1,39 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Denna kamera är redan konfiguerad"
+        },
+        "error": {
+            "cannot_connect": "Misslyckades med att ansluta till kameran",
+            "invalid_auth": "Fel användarnamn eller lösenord",
+            "unknown": "Oförväntat fel"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "port": "Port",
+                    "username": "Användarnamn",
+                    "password": "Lösenord"
+                }
+            },
+            "nvr": {
+                "data": {
+                    "channel": "Kanal"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "protocol": "Protokoll",
+                    "stream": "Ström",
+                    "timeout": "Timeout (sekunder)",
+					"motion_off_delay": "Rörelsesensor avstängningfördröjning (sekunder)"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since I run the pyvenv installation of HomeAssistant I haven't been able to try it out. But since it's just translations, I don't see where this could go wrong (UTF-8?).