### PR TITLE
Add missing/required info

### DIFF
--- a/custom_components/reolink_dev/manifest.json
+++ b/custom_components/reolink_dev/manifest.json
@@ -3,6 +3,7 @@
   "name": "Reolink IP camera",
   "documentation": "https://github.com/fwestenberg/reolink_dev",
   "issue_tracker": "https://github.com/fwestenberg/reolink_dev/issues",
+  "version": "0.15",
   "requirements": ["reolink==0.0.15"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@fwestenberg"],

--- a/custom_components/reolink_dev/services.yaml
+++ b/custom_components/reolink_dev/services.yaml
@@ -1,5 +1,10 @@
 ptz_control:
+  name: Pan/Zoom/Tilt Control
   description: Execute a PTZ command.
+  target:
+    entity:
+      integration: reolink_dev
+      domain: camera
   fields:
     entity_id:
       description: Name(s) of the Reolink camera entity to execute the command on.
@@ -12,16 +17,21 @@ ptz_control:
       example: LEFTUP
     preset:
       description: (Optional) In case of the command TOPOS. The available presets are listed as attribute on the camera.
-      example:
+      example: HOME
     speed:
       description: (Optional) Speed at which the movement takes place.
       example: 25
 
 set_sensitivity:
+  name: Set Motion Sensitivity
   description: Set the motion detection sensitivity.
+  target:
+    entity:
+      integration: reolink_dev
+      domain: camera
   fields:
     entity_id:
-      description: Name(s) of the Reolink camera entity for which the sensitivity value should be set.
+      description: Name(s) of the Reolink camera entity to execute the command on.
       example: 'camera.frontdoor'
     sensitivity:
       description: New sensitivity, value between 1 (low sensitivity) and 50 (high sensitivity)
@@ -32,10 +42,15 @@ set_sensitivity:
         all presets will be changed.
 
 set_daynight:
+  name: Set Day/Night Mode
   description: Set day and night parameter.
+  target:
+    entity:
+      integration: reolink_dev
+      domain: camera
   fields:
     entity_id:
-      description: Name(s) of the Reolink camera entity for which the day and night value should be set.
+      description: Name(s) of the Reolink camera entity to execute the command on.
       example: 'camera.frontdoor'
     mode:
       description: >-

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Reolink IP camera",
   "domains": "camera",
-  "iot_class": "Local Push"
+  "iot_class": "Local Push",
+  "homeassistant": "2021.2.3"
 }


### PR DESCRIPTION
This should add any missing info for the hassfest validation, and bring the repo in-line with the current 2021.3.2 version. I set the version in manifest to what I believe your next release would be, and I tested the changes as far back as 2021.2.3, and set that version in the hacs.json. If you want I can test back to an older version to make sure the services.yaml changes to break anything, and then set the hacs.json to that version, but I think going forward 2021.2.3 is a good starting point.

The additional changes to the services.yaml adds support for the new target entry for targeting an entity_id by area/integration/device.