### PR TITLE
Add info on user types to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Enter the details for your camera. The camera and other sensors will now be avai
 
 For the motion detection to work, Home Assistant must be reachable via http from your local network. So when using https internally, motion detection will not work at this moment.
 
+For the services and switch entities of this integration to work, you need a camera user of type "Administrator". Users of type "Guest" can only view the switch states but cannot change them and cannot call the services. Users are created and managed through the web interface of the camera (Device Settings / Cog icon -> User) or through the app (Device Settings / Cog icon -> Advanced -> User Management).
+
 ## Services
 
 The Reolink integration supports all default camera [services](https://www.home-assistant.io/integrations/camera/#services) and additionally provides the following services:


### PR DESCRIPTION
The Reolink cameras support two user account types: Administrator and Guest
Only Administrators are able to use the control functions of this integration, i.e. service calls and changes of switch states.
This PR adds a corresponding explanation to the README.md. No code changes.