### PR TITLE
Fix accidental use of 3.9 syntax

### DIFF
--- a/custom_components/reolink_dev/typings.py
+++ b/custom_components/reolink_dev/typings.py
@@ -1,6 +1,6 @@
 """ Typing declarations for strongly typed dictionaries """
 
-from typing import Any, List, TypedDict
+from typing import Any, Dict, List, TypedDict
 from datetime import datetime, date
 
 VodEvent = TypedDict(
@@ -25,7 +25,7 @@ MediaSourceCacheEntry = TypedDict(
         "playback_thumbnails": bool,
         "playback_thumbnail_offset": int,
         "playback_day_entries": List[date],
-        "playback_events": dict[str, VodEvent],
+        "playback_events": Dict[str, VodEvent],
     },
     total=False,
 )


### PR DESCRIPTION
This fixes the error I caused by using the wrong dev environment. I tested this against Python 3.8.5 and Home assistant 2021.3.4, and the media source does work correctly.