### PR TITLE
Better thumbnails

### DIFF
--- a/custom_components/reolink_dev/media_source.py
+++ b/custom_components/reolink_dev/media_source.py
@@ -428,7 +428,7 @@ class ReolinkSourceThumbnailView(HomeAssistantView):
 
             extra_cmd: List[str] = None
             if cache["playback_thumbnail_offset"] > 0:
-                extra_cmd = ["-ss", cache["playback_thumbnail_offset"]]
+                extra_cmd = ["-ss", str(cache["playback_thumbnail_offset"])]
 
             tasks = self._tasks.setdefault(base.api.host, {})
             url = await base.api.get_vod_source(event["file"])


### PR DESCRIPTION
This fixes the thumbnail generation issues and keeps the thumbs on the file system instead of in memory (for an HD cam it s around 400K per thumb depending on the recording settings)
There is no cleanup of expired video thumbs at this time, so down the road that could be an issue, manual cleanup would just be deleting the .storage/reolink_dev/thumbnails folder under the config directory. Better cleanup should be done in the future.

This also should prevent cameras with no storage from being listed in playbacks, but that is not fully tested.

In addition this works around the issue of not rescanning when a capture occurs on a new day, but this needs the pull request in the reolink repo otherwise errors will occur on days with no recordings.

update:
Added a small bit to cleanup thumbnails, wont handle a removed camera, but should keep the folder from "exploding" as long as either the instance is reloaded or the months to keep changes.