### PR TITLE
add ext (balanced) stream quality  option

### DIFF
--- a/custom_components/reolink_dev/config_flow.py
+++ b/custom_components/reolink_dev/config_flow.py
@@ -176,7 +176,7 @@ class ReolinkOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             CONF_STREAM, DEFAULT_STREAM
                         ),): vol.In(
-                        ["main", "sub"]
+                        ["main", "sub", "ext"]
                     ),
                     vol.Required(CONF_STREAM_FORMAT, 
                     default=self.config_entry.options.get(


### PR DESCRIPTION
add ext stream option to enable live stream from [ext](https://support.reolink.com/hc/en-us/article_attachments/4406723274521/Reolink-url-command-v2.docx) stream.

this fixes my issue:
https://github.com/fwestenberg/reolink_dev/issues/242#issuecomment-949980778

I use camera hooked to a NVR:

| NVR |  |
| --- | --- |
| Model | RLN8-410 |
| Build No. | build 21101146 |
| Hardware No. | N3MB01 |
| Config Version | v3.0.0.0 |
| Firmware Version | v3.0.0.148_21101146 |

| Camera | |
|---|---|
| Model | RLC-820A |
| Firmware version | v3.0.0.494 |

reconfiguring the integration with `ext` stream and `h264`/`h265` codec + reloading the integrtion worked  