### PR TITLE
Fix MJPEG stream

### DIFF
--- a/custom_components/reolink_dev/camera.py
+++ b/custom_components/reolink_dev/camera.py
@@ -1,21 +1,14 @@
 """This component provides support for Reolink IP cameras."""
-import asyncio
 from datetime import datetime
 import logging
 from typing import Union
 
 import voluptuous as vol
 
-from haffmpeg.camera import CameraMjpeg
 from homeassistant.components.camera import SUPPORT_STREAM, Camera
 from homeassistant.components.ffmpeg import DATA_FFMPEG
 
 from homeassistant.helpers import config_validation as cv, entity_platform
-from homeassistant.helpers.aiohttp_client import (
-    async_aiohttp_proxy_web,
-    async_aiohttp_proxy_stream,
-    async_get_clientsession,
-)
 
 from .const import (
     DOMAIN_DATA,
@@ -192,23 +185,6 @@ class ReolinkCamera(ReolinkEntity, Camera):
     async def stream_source(self):
         """Return the source of the stream."""
         return await self._base.api.get_stream_source()
-
-    async def handle_async_mjpeg_stream(self, request):
-        """Generate an HTTP MJPEG stream from the camera."""
-
-        stream = CameraMjpeg(self._ffmpeg.binary)
-        await stream.open_camera(self._input, extra_cmd=self._extra_arguments)
-
-        try:
-            stream_reader = await stream.get_reader()
-            return await async_aiohttp_proxy_stream(
-                self.hass,
-                request,
-                stream_reader,
-                self._ffmpeg.ffmpeg_stream_content_type,
-            )
-        finally:
-            await stream.close()
 
     async def async_camera_image(
         self, width: Union[int, None] = None, height: Union[int, None] = None


### PR DESCRIPTION
Stop overriding [FFmpegCamera's `handle_async_mjpeg_stream()`](https://github.com/home-assistant/core/blob/00b1c2bb70a781241f8a68b9429e4e1dccf0c379/homeassistant/components/ffmpeg/camera.py#L64-L79) to fix `AttributeError: 'ReolinkCamera' object has no attribute '_input'`. The original code is identical but has access to `self._input`.

Fixes https://github.com/fwestenberg/reolink_dev/issues/346, https://github.com/fwestenberg/reolink_dev/issues/278 and possibly https://github.com/fwestenberg/reolink_dev/issues/354.