### PR TITLE
Motion and AI states fixes

### DIFF
--- a/custom_components/reolink_dev/base.py
+++ b/custom_components/reolink_dev/base.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_PROTOCOL,
     CONF_STREAM,
     CONF_STREAM_FORMAT,
+    CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY,
     DEFAULT_USE_HTTPS,
     DEFAULT_CHANNEL,
     DEFAULT_MOTION_OFF_DELAY,
@@ -45,6 +46,7 @@ from .const import (
     DEFAULT_STREAM,
     DEFAULT_STREAM_FORMAT,
     DEFAULT_TIMEOUT,
+    DEFAULT_MOTION_STATES_UPDATE_FALLBACK_DELAY,
     DOMAIN,
     PUSH_MANAGER,
     SESSION_RENEW_THRESHOLD,
@@ -139,6 +141,13 @@ class ReolinkBase:
             self._thumbnail_path = None
         else:
             self._thumbnail_path: str = options[CONF_THUMBNAIL_PATH]
+
+        from .binary_sensor import MotionSensor, ObjectDetectedSensor
+
+        if CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY not in options:
+            self.motion_states_update_fallback_delay = DEFAULT_MOTION_STATES_UPDATE_FALLBACK_DELAY
+        else:
+            self.motion_states_update_fallback_delay = options[CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY]
 
         from .binary_sensor import MotionSensor, ObjectDetectedSensor
 

--- a/custom_components/reolink_dev/binary_sensor.py
+++ b/custom_components/reolink_dev/binary_sensor.py
@@ -86,7 +86,9 @@ class MotionSensor(ReolinkEntity, BinarySensorEntity):
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._available
+        if self._base.motion_states_update_fallback_delay is None or self._base.motion_states_update_fallback_delay <= 0:
+            return self._available
+        return self._base.api.session_active
 
     @property
     def device_class(self):
@@ -245,13 +247,14 @@ class ObjectDetectedSensor(ReolinkEntity, BinarySensorEntity):
     def is_on(self):
         """Return the state of the sensor."""
         self._state = self._event_state
-
         return self._state
 
     @property
     def available(self):
         """Return True if entity is available."""
-        return self._available
+        if self._base.motion_states_update_fallback_delay is None or self._base.motion_states_update_fallback_delay <= 0:
+            return self._available
+        return self._base.api.ai_state and self._base.api.session_active
 
     @property
     def device_class(self):

--- a/custom_components/reolink_dev/binary_sensor.py
+++ b/custom_components/reolink_dev/binary_sensor.py
@@ -4,11 +4,11 @@ import datetime
 import logging
 import traceback
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, Event
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from .entity import ReolinkEntity
-from .const import BASE, DOMAIN
+from .entity import ReolinkEntity, CoordinatorEntity
+from .const import BASE, DOMAIN, MOTION_UPDATE_COORDINATOR
 from .base import ReolinkBase
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +46,7 @@ class MotionSensor(ReolinkEntity, BinarySensorEntity):
         """Initialize a the switch."""
         ReolinkEntity.__init__(self, hass, config)
         BinarySensorEntity.__init__(self)
+        CoordinatorEntity.__init__(self, hass.data[DOMAIN][config.entry_id][MOTION_UPDATE_COORDINATOR])
 
         self._available = False
         self._event_state = False
@@ -125,13 +126,21 @@ class MotionSensor(ReolinkEntity, BinarySensorEntity):
 
         if self._event_state:
             self._last_motion = datetime.datetime.now()
-
-            if self._base.api.ai_state:
-                # send an event to AI based motion sensor entities
-                self._hass.bus.async_fire(self._base.event_id, {"ai_refreshed": True})
         else:
             if self._base.motion_off_delay > 0:
                 await asyncio.sleep(self._base.motion_off_delay)
+
+        if self._base.api.ai_state:
+            # send an event to AI based motion sensor entities
+            if self._base.sensor_person_detection is not None:
+                await self._base.sensor_person_detection.handle_event(
+                    Event(self._base.event_id, {"ai_refreshed": True}))
+            if self._base.sensor_vehicle_detection is not None:
+                await self._base.sensor_vehicle_detection.handle_event(
+                    Event(self._base.event_id, {"ai_refreshed": True}))
+            if self._base.sensor_pet_detection is not None:
+                await self._base.sensor_pet_detection.handle_event(
+                    Event(self._base.event_id, {"ai_refreshed": True}))
 
         if self.enabled:
             self.async_schedule_update_ha_state()
@@ -183,6 +192,10 @@ class MotionSensor(ReolinkEntity, BinarySensorEntity):
                     attrs[key] = False
 
         return attrs
+
+    async def request_refresh(self):
+        """Call the coordinator to update the API."""
+        await self.coordinator.async_request_refresh()
 
 
 class ObjectDetectedSensor(ReolinkEntity, BinarySensorEntity):

--- a/custom_components/reolink_dev/config_flow.py
+++ b/custom_components/reolink_dev/config_flow.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_STREAM,
     CONF_STREAM_FORMAT,
     CONF_THUMBNAIL_PATH,
+    CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY,
     DEFAULT_MOTION_OFF_DELAY,
     DEFAULT_USE_HTTPS,
     DEFAULT_PLAYBACK_MONTHS,
@@ -35,6 +36,7 @@ from .const import (
     DEFAULT_STREAM_FORMAT,
     DEFAULT_THUMBNAIL_PATH,
     DEFAULT_TIMEOUT,
+    DEFAULT_MOTION_STATES_UPDATE_FALLBACK_DELAY,
     DOMAIN,
 )
 
@@ -178,19 +180,24 @@ class ReolinkOptionsFlowHandler(config_entries.OptionsFlow):
                         ),): vol.In(
                         ["main", "sub", "ext"]
                     ),
-                    vol.Required(CONF_STREAM_FORMAT, 
-                    default=self.config_entry.options.get(
-                            CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT
-                        ),): vol.In(
+                    vol.Required(CONF_STREAM_FORMAT,
+                                 default=self.config_entry.options.get(
+                                     CONF_STREAM_FORMAT, DEFAULT_STREAM_FORMAT
+                                 ), ): vol.In(
                         ["h264", "h265"]
                     ),
-
                     vol.Required(
                         CONF_MOTION_OFF_DELAY,
                         default=self.config_entry.options.get(
                             CONF_MOTION_OFF_DELAY, DEFAULT_MOTION_OFF_DELAY
                         ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                    vol.Required(
+                        CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY,
+                        default=self.config_entry.options.get(
+                            CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY, DEFAULT_MOTION_STATES_UPDATE_FALLBACK_DELAY
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=60)),
                     vol.Required(
                         CONF_PLAYBACK_MONTHS,
                         default=self.config_entry.options.get(

--- a/custom_components/reolink_dev/const.py
+++ b/custom_components/reolink_dev/const.py
@@ -4,6 +4,7 @@ DOMAIN = "reolink_dev"
 DOMAIN_DATA = "reolink_dev_devices"
 EVENT_DATA_RECEIVED = "reolink_dev-event"
 COORDINATOR = "coordinator"
+MOTION_UPDATE_COORDINATOR = "motion_update_coordinator"
 BASE = "base"
 PUSH_MANAGER = "push_manager"
 SESSION_RENEW_THRESHOLD = 300
@@ -21,6 +22,7 @@ CONF_CHANNEL = "channel"
 CONF_MOTION_OFF_DELAY = "motion_off_delay"
 CONF_PLAYBACK_MONTHS = "playback_months"
 CONF_THUMBNAIL_PATH = "playback_thumbnail_path"
+CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY = "motion_states_update_fallback_delay"
 
 DEFAULT_USE_HTTPS = True
 DEFAULT_CHANNEL = 1
@@ -28,6 +30,7 @@ DEFAULT_MOTION_OFF_DELAY = 60
 DEFAULT_PROTOCOL = "rtmp"
 DEFAULT_STREAM = "main"
 DEFAULT_STREAM_FORMAT = "h264"
+DEFAULT_MOTION_STATES_UPDATE_FALLBACK_DELAY = 30
 
 DEFAULT_TIMEOUT = 30
 DEFAULT_PLAYBACK_MONTHS = 2

--- a/custom_components/reolink_dev/entity.py
+++ b/custom_components/reolink_dev/entity.py
@@ -4,7 +4,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BASE, COORDINATOR, DOMAIN
+from .const import BASE, COORDINATOR, DOMAIN, MOTION_UPDATE_COORDINATOR
 from .base import ReolinkBase
 
 

--- a/custom_components/reolink_dev/strings.json
+++ b/custom_components/reolink_dev/strings.json
@@ -32,6 +32,7 @@
           "protocol": "Protocol",
           "stream": "Stream",
           "timeout": "Timeout",
+          "motion_states_update_fallback_delay": "Motion states update fallback delay (seconds, 0 or less to disable)",
           "motion_off_delay": "Motion sensor off delay (seconds)",
           "playback_months": "Playback range (months)",
           "playback_thumbnail_path": "Custom thumbnail path",

--- a/custom_components/reolink_dev/translations/en.json
+++ b/custom_components/reolink_dev/translations/en.json
@@ -32,6 +32,7 @@
                     "protocol": "Protocol",
                     "stream": "Stream",
                     "timeout": "Timeout (seconds)",
+                    "motion_states_update_fallback_delay": "Motion states update fallback delay (seconds, 0 or less to disable): Reolink's event subscription is not always reliable, this will help to avoid event misses",
                     "motion_off_delay": "Motion sensor off delay (seconds)",
                     "playback_months": "Playback range (months)",
                     "playback_thumbnails": "Create thumbnails for playback items",


### PR DESCRIPTION
- a default 30 seconds timer loop will refresh Motion and AI sensors in case webhook is not reliable (which is a broad issue!). Go down to 2-5 seconds if you want to rely solely on this rather than webhook.
- their availability will now depend on API reachability rather than Webhook