### PR TITLE
Add optional SMTP server for event based AI detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ This integration creates a camera entity, providing a live-stream configurable f
 | Protocol                | Switch between the RTMP or RTSP streaming protocol.                                                         |
 | Channel                 | When using a single camera, choose stream 0. When using a NVR, switch between the different camera streams. |
 
-## Binary Sensor
+## Binary Sensors
 
-When the camera supports motion detection events, a binary sensor is created for real-time motion detection. The time to switch motion detection off can be configured via the options menu, located at the integrations page. Please notice: for using the motion detection, your Homa Assistant should be reachable (within you local network) over http (not https).
+When the camera supports motion detection events, a binary sensor is created for real-time motion detection. The time to switch motion detection off can be configured via the options menu, located at the integrations page. Please notice: for using the motion detection, your Homa Assistant should be reachable (within your local network) over http (not https).
 
 | Parameter               | Description                                                                                                 |
 | :-------------------    | :---------------------------------------------------------------------------------------------------------- |
@@ -120,7 +120,22 @@ When the camera supports motion detection events, a binary sensor is created for
 
 When the camera supports AI objects detection, a binary sensor is created for each type of object (person, vehicle, pet)
 
-## Switch
+The cameras only support webhooks for motion start/stop, and not any of the AI detections (person/vehicle/pet).
+This may change in future firmware, but AI detections must be polled for now.
+Optionally configure camera to send an email via SMTP on AI detection, and receive it in this Home Assistant plugin.
+This allows event based start of AI detection start, but not stop.
+The AI detection will be cleared in the next poll update.
+Camera should be configured to email on person/vehicle detection (not motion), use Home Assistant's IP address, disable SSL/TLS, and select an arbitrary SMTP port.
+The SMTP port should be unique for each integration.
+Text, Text with Picture, and Text with Video will all work for email content, but there may be unnecessary delay with the picture or video options.
+Other email fields in the camera configuration don't matter.
+Tested on individual cameras, but not NVRs.
+
+| Parameter               | Description                                                                                                 |
+| :-------------------    | :---------------------------------------------------------------------------------------------------------- |
+| SMTP port               | Optional port to listen for email event for AI detections. Default is 0 (disable).                          |
+
+## Switches
 
 Depending on the camera, the following switches are created:
 

--- a/custom_components/reolink_dev/__init__.py
+++ b/custom_components/reolink_dev/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     BASE,
     CONF_CHANNEL,
     CONF_USE_HTTPS,
+    CONF_SMTP_PORT,
     CONF_MOTION_OFF_DELAY,
     CONF_PLAYBACK_MONTHS,
     CONF_PROTOCOL,
@@ -32,6 +33,7 @@ from .const import (
     CONF_THUMBNAIL_PATH,
     CONF_STREAM_FORMAT,
     CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY,
+    DEFAULT_SMTP_PORT,
     COORDINATOR,
     MOTION_UPDATE_COORDINATOR,
     DOMAIN,
@@ -93,6 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_PASSWORD],
         )
         await push.subscribe(base.event_id)
+        await push.set_smtp_port(entry.options.get(CONF_SMTP_PORT, DEFAULT_SMTP_PORT))
         hass.data[DOMAIN][base.push_manager] = push
 
     async def async_update_data():
@@ -159,6 +162,7 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
     await base.set_protocol(entry.options[CONF_PROTOCOL])
     await base.set_stream(entry.options[CONF_STREAM])
     await base.set_stream_format(entry.options[CONF_STREAM_FORMAT])
+    await base.set_smtp_port(entry.options[CONF_SMTP_PORT])
 
     motion_state_coordinator: DataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][MOTION_UPDATE_COORDINATOR]
 
@@ -181,6 +185,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     base = hass.data[DOMAIN][entry.entry_id][BASE]
     push = hass.data[DOMAIN][base.push_manager]
+
+    await base.set_smtp_port(0) # Stop SMTP server
 
     if not await push.count_members() > 1:
         await push.unsubscribe()

--- a/custom_components/reolink_dev/binary_sensor.py
+++ b/custom_components/reolink_dev/binary_sensor.py
@@ -294,6 +294,11 @@ class ObjectDetectedSensor(ReolinkEntity, BinarySensorEntity):
         except KeyError:
             pass
 
+        if event.data.get("smtp") is self._object_type:
+            self._event_state = True
+            if self.enabled:
+                self.async_schedule_update_ha_state()
+
         if event.data.get("ai_refreshed") is not True:
             return
 

--- a/custom_components/reolink_dev/config_flow.py
+++ b/custom_components/reolink_dev/config_flow.py
@@ -21,6 +21,7 @@ from .const import (
     BASE,
     CONF_CHANNEL,
     CONF_USE_HTTPS,
+    CONF_SMTP_PORT,
     CONF_MOTION_OFF_DELAY,
     CONF_PLAYBACK_MONTHS,
     CONF_PROTOCOL,
@@ -28,6 +29,7 @@ from .const import (
     CONF_STREAM_FORMAT,
     CONF_THUMBNAIL_PATH,
     CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY,
+    DEFAULT_SMTP_PORT,
     DEFAULT_MOTION_OFF_DELAY,
     DEFAULT_USE_HTTPS,
     DEFAULT_PLAYBACK_MONTHS,
@@ -186,6 +188,12 @@ class ReolinkOptionsFlowHandler(config_entries.OptionsFlow):
                                  ), ): vol.In(
                         ["h264", "h265"]
                     ),
+                    vol.Required(
+                        CONF_SMTP_PORT,
+                        default=self.config_entry.options.get(
+                            CONF_SMTP_PORT, DEFAULT_SMTP_PORT
+                        ),
+                    ): cv.positive_int,
                     vol.Required(
                         CONF_MOTION_OFF_DELAY,
                         default=self.config_entry.options.get(

--- a/custom_components/reolink_dev/const.py
+++ b/custom_components/reolink_dev/const.py
@@ -19,6 +19,7 @@ CONF_STREAM = "stream"
 CONF_STREAM_FORMAT = "stream_format"
 CONF_PROTOCOL = "protocol"
 CONF_CHANNEL = "channel"
+CONF_SMTP_PORT = "smtp_port"
 CONF_MOTION_OFF_DELAY = "motion_off_delay"
 CONF_PLAYBACK_MONTHS = "playback_months"
 CONF_THUMBNAIL_PATH = "playback_thumbnail_path"
@@ -26,6 +27,7 @@ CONF_MOTION_STATES_UPDATE_FALLBACK_DELAY = "motion_states_update_fallback_delay"
 
 DEFAULT_USE_HTTPS = True
 DEFAULT_CHANNEL = 1
+DEFAULT_SMTP_PORT = 0
 DEFAULT_MOTION_OFF_DELAY = 60
 DEFAULT_PROTOCOL = "rtmp"
 DEFAULT_STREAM = "main"

--- a/custom_components/reolink_dev/manifest.json
+++ b/custom_components/reolink_dev/manifest.json
@@ -6,7 +6,8 @@
   "version": "0.57",
   "iot_class": "local_polling",
   "requirements": [
-    "reolink==0.0.62"
+    "reolink==0.0.62",
+    "aiosmtpd>=1.4.2"
   ],
   "dependencies": [
     "ffmpeg",

--- a/custom_components/reolink_dev/strings.json
+++ b/custom_components/reolink_dev/strings.json
@@ -32,11 +32,12 @@
           "protocol": "Protocol",
           "stream": "Stream",
           "timeout": "Timeout",
+          "smtp_port": "SMTP port for AI detection events (0 to disable)",
           "motion_states_update_fallback_delay": "Motion states update fallback delay (seconds, 0 or less to disable)",
           "motion_off_delay": "Motion sensor off delay (seconds)",
           "playback_months": "Playback range (months)",
           "playback_thumbnail_path": "Custom thumbnail path",
-            "stream_format": "Stream format"
+          "stream_format": "Stream format"
         }
       }
     }

--- a/custom_components/reolink_dev/translations/en.json
+++ b/custom_components/reolink_dev/translations/en.json
@@ -32,6 +32,7 @@
                     "protocol": "Protocol",
                     "stream": "Stream",
                     "timeout": "Timeout (seconds)",
+                    "smtp_port": "SMTP port for AI detection events (0 to disable)",
                     "motion_states_update_fallback_delay": "Motion states update fallback delay (seconds, 0 or less to disable): Reolink's event subscription is not always reliable, this will help to avoid event misses",
                     "motion_off_delay": "Motion sensor off delay (seconds)",
                     "playback_months": "Playback range (months)",


### PR DESCRIPTION
Webhooks provide event based motion detection, but not AI detection
SMTP event for AI detection start, cleared on next periodic update