### PR TITLE
Enabling Pet motion sensor

### DIFF
--- a/custom_components/reolink_dev/base.py
+++ b/custom_components/reolink_dev/base.py
@@ -132,6 +132,7 @@ class ReolinkBase:
         self.motion_detection_state = True
         self.object_person_detection_state = True
         self.object_vehicle_detection_state = True
+        self.object_pet_detection_state = True
 
         if CONF_MOTION_OFF_DELAY not in options:
             self.motion_off_delay = DEFAULT_MOTION_OFF_DELAY

--- a/custom_components/reolink_dev/binary_sensor.py
+++ b/custom_components/reolink_dev/binary_sensor.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
                       format(base.name, base.api.model))
         base.sensor_person_detection = ObjectDetectedSensor(hass, config_entry, "person")
         base.sensor_vehicle_detection = ObjectDetectedSensor(hass, config_entry, "vehicle")
-        base.sensor_pet_detection = ObjectDetectedSensor(hass, config_entry, "pet")
+        base.sensor_pet_detection = ObjectDetectedSensor(hass, config_entry, "dog_cat")
 
         new_sensors.append(base.sensor_person_detection)
         new_sensors.append(base.sensor_vehicle_detection)
@@ -233,7 +233,7 @@ class ObjectDetectedSensor(ReolinkEntity, BinarySensorEntity):
     def icon(self):
         """Icon of the sensor."""
 
-        if self._object_type == "pet":
+        if self._object_type == "dog_cat":
             if self._state:
                 return "mdi:dog-side"
             else:


### PR DESCRIPTION
The "Pet" binary motion sensor doesn't work with 820A cameras on latest firmware. According to issue #512 , this should solve the problem.